### PR TITLE
Add support for default branch and build skipping

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -12,23 +12,23 @@ import (
 
 // PipelineNode represents a pipeline as returned from the GraphQL API
 type PipelineNode struct {
-	DefaultBranch graphql.String
-	Description   graphql.String
-	Id            graphql.String
-	Name          graphql.String
-	Repository    struct {
-		Url graphql.String
-	}
-	Slug  graphql.String
-	Steps struct {
-		Yaml graphql.String
-	}
-	Uuid                                 graphql.String
-	WebhookURL                           graphql.String `graphql:"webhookURL"`
-	SkipIntermediateBuilds               graphql.Boolean
-	SkipIntermediateBuildsBranchFilter   graphql.String
 	CancelIntermediateBuilds             graphql.Boolean
 	CancelIntermediateBuildsBranchFilter graphql.String
+	DefaultBranch                        graphql.String
+	Description                          graphql.String
+	Id                                   graphql.String
+	Name                                 graphql.String
+	Repository                           struct {
+		Url graphql.String
+	}
+	SkipIntermediateBuilds             graphql.Boolean
+	SkipIntermediateBuildsBranchFilter graphql.String
+	Slug                               graphql.String
+	Steps                              struct {
+		Yaml graphql.String
+	}
+	Uuid       graphql.String
+	WebhookURL graphql.String `graphql:"webhookURL"`
 }
 
 func resourcePipeline() *schema.Resource {
@@ -42,32 +42,28 @@ func resourcePipeline() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
-				Required: true,
+			"cancel_intermediate_builds": &schema.Schema{
+				Optional: true,
+				Type:     schema.TypeBool,
+			},
+			"cancel_intermediate_builds_branch_filter": &schema.Schema{
+				Optional: true,
+				Type:     schema.TypeString,
+			},
+			"default_branch": &schema.Schema{
+				Optional: true,
 				Type:     schema.TypeString,
 			},
 			"description": &schema.Schema{
 				Optional: true,
 				Type:     schema.TypeString,
 			},
+			"name": &schema.Schema{
+				Required: true,
+				Type:     schema.TypeString,
+			},
 			"repository": &schema.Schema{
 				Required: true,
-				Type:     schema.TypeString,
-			},
-			"webhook_url": &schema.Schema{
-				Computed: true,
-				Type:     schema.TypeString,
-			},
-			"slug": &schema.Schema{
-				Computed: true,
-				Type:     schema.TypeString,
-			},
-			"steps": &schema.Schema{
-				Required: true,
-				Type:     schema.TypeString,
-			},
-			"default_branch": &schema.Schema{
-				Optional: true,
 				Type:     schema.TypeString,
 			},
 			"skip_intermediate_builds": &schema.Schema{
@@ -78,12 +74,16 @@ func resourcePipeline() *schema.Resource {
 				Optional: true,
 				Type:     schema.TypeString,
 			},
-			"cancel_intermediate_builds": &schema.Schema{
-				Optional: true,
-				Type:     schema.TypeBool,
+			"slug": &schema.Schema{
+				Computed: true,
+				Type:     schema.TypeString,
 			},
-			"cancel_intermediate_builds_branch_filter": &schema.Schema{
-				Optional: true,
+			"steps": &schema.Schema{
+				Required: true,
+				Type:     schema.TypeString,
+			},
+			"webhook_url": &schema.Schema{
+				Computed: true,
 				Type:     schema.TypeString,
 			},
 		},
@@ -101,20 +101,20 @@ func CreatePipeline(d *schema.ResourceData, m interface{}) error {
 	var mutation struct {
 		PipelineCreate struct {
 			Pipeline PipelineNode
-		} `graphql:"pipelineCreate(input: {organizationId: $org, name: $name, description: $desc, repository: {url: $repository_url}, steps: {yaml: $steps}, defaultBranch: $default_branch, skipIntermediateBuilds: $skip_intermediate_builds, skipIntermediateBuildsBranchFilter: $skip_intermediate_builds_branch_filter, cancelIntermediateBuilds: $cancel_intermediate_builds, cancelIntermediateBuildsBranchFilter: $cancel_intermediate_builds_branch_filter})"`
+		} `graphql:"pipelineCreate(input: {cancelIntermediateBuilds: $cancel_intermediate_builds, cancelIntermediateBuildsBranchFilter: $cancel_intermediate_builds_branch_filter, defaultBranch: $default_branch, description: $desc, name: $name, organizationId: $org, repository: {url: $repository_url}, skipIntermediateBuilds: $skip_intermediate_builds, skipIntermediateBuildsBranchFilter: $skip_intermediate_builds_branch_filter, steps: {yaml: $steps}})"`
 	}
 
 	vars := map[string]interface{}{
-		"desc":                                   graphql.String(d.Get("description").(string)),
-		"name":                                   graphql.String(d.Get("name").(string)),
-		"org":                                    id,
-		"repository_url":                         graphql.String(d.Get("repository").(string)),
-		"steps":                                  graphql.String(d.Get("steps").(string)),
-		"default_branch":                         graphql.String(d.Get("default_branch").(string)),
-		"skip_intermediate_builds":               graphql.Boolean(d.Get("skip_intermediate_builds").(bool)),
-		"skip_intermediate_builds_branch_filter": graphql.String(d.Get("skip_intermediate_builds_branch_filter").(string)),
-		"cancel_intermediate_builds":             graphql.Boolean(d.Get("cancel_intermediate_builds").(bool)),
+		"cancel_intermediate_builds":               graphql.Boolean(d.Get("cancel_intermediate_builds").(bool)),
 		"cancel_intermediate_builds_branch_filter": graphql.String(d.Get("cancel_intermediate_builds_branch_filter").(string)),
+		"default_branch":                           graphql.String(d.Get("default_branch").(string)),
+		"desc":                                     graphql.String(d.Get("description").(string)),
+		"name":                                     graphql.String(d.Get("name").(string)),
+		"org":                                      id,
+		"repository_url":                           graphql.String(d.Get("repository").(string)),
+		"skip_intermediate_builds":                 graphql.Boolean(d.Get("skip_intermediate_builds").(bool)),
+		"skip_intermediate_builds_branch_filter":   graphql.String(d.Get("skip_intermediate_builds_branch_filter").(string)),
+		"steps":                                    graphql.String(d.Get("steps").(string)),
 	}
 
 	err = client.graphql.Mutate(context.Background(), &mutation, vars)
@@ -157,20 +157,20 @@ func UpdatePipeline(d *schema.ResourceData, m interface{}) error {
 	var mutation struct {
 		PipelineUpdate struct {
 			Pipeline PipelineNode
-		} `graphql:"pipelineUpdate(input: {id: $id, name: $name, description: $desc, repository: {url: $repository_url}, steps: {yaml: $steps}, defaultBranch: $default_branch, skipIntermediateBuilds: $skip_intermediate_builds, skipIntermediateBuildsBranchFilter: $skip_intermediate_builds_branch_filter, cancelIntermediateBuilds: $cancel_intermediate_builds, cancelIntermediateBuildsBranchFilter: $cancel_intermediate_builds_branch_filter})"`
+		} `graphql:"pipelineUpdate(input: {cancelIntermediateBuilds: $cancel_intermediate_builds, cancelIntermediateBuildsBranchFilter: $cancel_intermediate_builds_branch_filter, defaultBranch: $default_branch, description: $desc, id: $id, name: $name, repository: {url: $repository_url}, skipIntermediateBuilds: $skip_intermediate_builds, skipIntermediateBuildsBranchFilter: $skip_intermediate_builds_branch_filter, steps: {yaml: $steps}})"`
 	}
 
 	vars := map[string]interface{}{
-		"desc":                                   graphql.String(d.Get("description").(string)),
-		"id":                                     graphql.ID(d.Id()),
-		"name":                                   graphql.String(d.Get("name").(string)),
-		"repository_url":                         graphql.String(d.Get("repository").(string)),
-		"steps":                                  graphql.String(d.Get("steps").(string)),
-		"default_branch":                         graphql.String(d.Get("default_branch").(string)),
-		"skip_intermediate_builds":               graphql.Boolean(d.Get("skip_intermediate_builds").(bool)),
-		"skip_intermediate_builds_branch_filter": graphql.String(d.Get("skip_intermediate_builds_branch_filter").(string)),
-		"cancel_intermediate_builds":             graphql.Boolean(d.Get("cancel_intermediate_builds").(bool)),
+		"cancel_intermediate_builds":               graphql.Boolean(d.Get("cancel_intermediate_builds").(bool)),
 		"cancel_intermediate_builds_branch_filter": graphql.String(d.Get("cancel_intermediate_builds_branch_filter").(string)),
+		"default_branch":                           graphql.String(d.Get("default_branch").(string)),
+		"desc":                                     graphql.String(d.Get("description").(string)),
+		"id":                                       graphql.ID(d.Id()),
+		"name":                                     graphql.String(d.Get("name").(string)),
+		"repository_url":                           graphql.String(d.Get("repository").(string)),
+		"skip_intermediate_builds":                 graphql.Boolean(d.Get("skip_intermediate_builds").(bool)),
+		"skip_intermediate_builds_branch_filter":   graphql.String(d.Get("skip_intermediate_builds_branch_filter").(string)),
+		"steps":                                    graphql.String(d.Get("steps").(string)),
 	}
 
 	err := client.graphql.Mutate(context.Background(), &mutation, vars)
@@ -205,16 +205,16 @@ func DeletePipeline(d *schema.ResourceData, m interface{}) error {
 
 func updatePipeline(d *schema.ResourceData, t *PipelineNode) {
 	d.SetId(string(t.Id))
+	d.Set("cancel_intermediate_builds", bool(t.CancelIntermediateBuilds))
+	d.Set("cancel_intermediate_builds_branch_filter", string(t.CancelIntermediateBuildsBranchFilter))
+	d.Set("default_branch", string(t.DefaultBranch))
 	d.Set("description", string(t.Description))
 	d.Set("name", string(t.Name))
 	d.Set("repository", string(t.Repository.Url))
+	d.Set("skip_intermediate_builds", bool(t.SkipIntermediateBuilds))
+	d.Set("skip_intermediate_builds_branch_filter", string(t.SkipIntermediateBuildsBranchFilter))
 	d.Set("slug", string(t.Slug))
 	d.Set("steps", string(t.Steps.Yaml))
 	d.Set("uuid", string(t.Uuid))
 	d.Set("webhook_url", string(t.WebhookURL))
-	d.Set("default_branch", string(t.DefaultBranch))
-	d.Set("skip_intermediate_builds", bool(t.SkipIntermediateBuilds))
-	d.Set("skip_intermediate_builds_branch_filter", string(t.SkipIntermediateBuildsBranchFilter))
-	d.Set("cancel_intermediate_builds", bool(t.CancelIntermediateBuilds))
-	d.Set("cancel_intermediate_builds_branch_filter", string(t.CancelIntermediateBuildsBranchFilter))
 }

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -23,8 +23,12 @@ type PipelineNode struct {
 	Steps struct {
 		Yaml graphql.String
 	}
-	Uuid       graphql.String
-	WebhookURL graphql.String `graphql:"webhookURL"`
+	Uuid                                 graphql.String
+	WebhookURL                           graphql.String `graphql:"webhookURL"`
+	SkipIntermediateBuilds               graphql.Boolean
+	SkipIntermediateBuildsBranchFilter   graphql.String
+	CancelIntermediateBuilds             graphql.Boolean
+	CancelIntermediateBuildsBranchFilter graphql.String
 }
 
 func resourcePipeline() *schema.Resource {
@@ -66,6 +70,22 @@ func resourcePipeline() *schema.Resource {
 				Optional: true,
 				Type:     schema.TypeString,
 			},
+			"skip_intermediate_builds": &schema.Schema{
+				Optional: true,
+				Type:     schema.TypeBool,
+			},
+			"skip_intermediate_builds_branch_filter": &schema.Schema{
+				Optional: true,
+				Type:     schema.TypeString,
+			},
+			"cancel_intermediate_builds": &schema.Schema{
+				Optional: true,
+				Type:     schema.TypeBool,
+			},
+			"cancel_intermediate_builds_branch_filter": &schema.Schema{
+				Optional: true,
+				Type:     schema.TypeString,
+			},
 		},
 	}
 }
@@ -81,16 +101,20 @@ func CreatePipeline(d *schema.ResourceData, m interface{}) error {
 	var mutation struct {
 		PipelineCreate struct {
 			Pipeline PipelineNode
-		} `graphql:"pipelineCreate(input: {organizationId: $org, name: $name, description: $desc, repository: {url: $repository_url}, steps: {yaml: $steps}, defaultBranch: $default_branch})"`
+		} `graphql:"pipelineCreate(input: {organizationId: $org, name: $name, description: $desc, repository: {url: $repository_url}, steps: {yaml: $steps}, defaultBranch: $default_branch, skipIntermediateBuilds: $skip_intermediate_builds, skipIntermediateBuildsBranchFilter: $skip_intermediate_builds_branch_filter, cancelIntermediateBuilds: $cancel_intermediate_builds, cancelIntermediateBuildsBranchFilter: $cancel_intermediate_builds_branch_filter})"`
 	}
 
 	vars := map[string]interface{}{
-		"desc":           graphql.String(d.Get("description").(string)),
-		"name":           graphql.String(d.Get("name").(string)),
-		"org":            id,
-		"repository_url": graphql.String(d.Get("repository").(string)),
-		"steps":          graphql.String(d.Get("steps").(string)),
-		"default_branch": graphql.String(d.Get("default_branch").(string)),
+		"desc":                                   graphql.String(d.Get("description").(string)),
+		"name":                                   graphql.String(d.Get("name").(string)),
+		"org":                                    id,
+		"repository_url":                         graphql.String(d.Get("repository").(string)),
+		"steps":                                  graphql.String(d.Get("steps").(string)),
+		"default_branch":                         graphql.String(d.Get("default_branch").(string)),
+		"skip_intermediate_builds":               graphql.Boolean(d.Get("skip_intermediate_builds").(bool)),
+		"skip_intermediate_builds_branch_filter": graphql.String(d.Get("skip_intermediate_builds_branch_filter").(string)),
+		"cancel_intermediate_builds":             graphql.Boolean(d.Get("cancel_intermediate_builds").(bool)),
+		"cancel_intermediate_builds_branch_filter": graphql.String(d.Get("cancel_intermediate_builds_branch_filter").(string)),
 	}
 
 	err = client.graphql.Mutate(context.Background(), &mutation, vars)
@@ -133,16 +157,20 @@ func UpdatePipeline(d *schema.ResourceData, m interface{}) error {
 	var mutation struct {
 		PipelineUpdate struct {
 			Pipeline PipelineNode
-		} `graphql:"pipelineUpdate(input: {id: $id, name: $name, description: $desc, repository: {url: $repository_url}, steps: {yaml: $steps}, defaultBranch: $default_branch})"`
+		} `graphql:"pipelineUpdate(input: {id: $id, name: $name, description: $desc, repository: {url: $repository_url}, steps: {yaml: $steps}, defaultBranch: $default_branch, skipIntermediateBuilds: $skip_intermediate_builds, skipIntermediateBuildsBranchFilter: $skip_intermediate_builds_branch_filter, cancelIntermediateBuilds: $cancel_intermediate_builds, cancelIntermediateBuildsBranchFilter: $cancel_intermediate_builds_branch_filter})"`
 	}
 
 	vars := map[string]interface{}{
-		"desc":           graphql.String(d.Get("description").(string)),
-		"id":             graphql.ID(d.Id()),
-		"name":           graphql.String(d.Get("name").(string)),
-		"repository_url": graphql.String(d.Get("repository").(string)),
-		"steps":          graphql.String(d.Get("steps").(string)),
-		"default_branch": graphql.String(d.Get("default_branch").(string)),
+		"desc":                                   graphql.String(d.Get("description").(string)),
+		"id":                                     graphql.ID(d.Id()),
+		"name":                                   graphql.String(d.Get("name").(string)),
+		"repository_url":                         graphql.String(d.Get("repository").(string)),
+		"steps":                                  graphql.String(d.Get("steps").(string)),
+		"default_branch":                         graphql.String(d.Get("default_branch").(string)),
+		"skip_intermediate_builds":               graphql.Boolean(d.Get("skip_intermediate_builds").(bool)),
+		"skip_intermediate_builds_branch_filter": graphql.String(d.Get("skip_intermediate_builds_branch_filter").(string)),
+		"cancel_intermediate_builds":             graphql.Boolean(d.Get("cancel_intermediate_builds").(bool)),
+		"cancel_intermediate_builds_branch_filter": graphql.String(d.Get("cancel_intermediate_builds_branch_filter").(string)),
 	}
 
 	err := client.graphql.Mutate(context.Background(), &mutation, vars)
@@ -185,4 +213,8 @@ func updatePipeline(d *schema.ResourceData, t *PipelineNode) {
 	d.Set("uuid", string(t.Uuid))
 	d.Set("webhook_url", string(t.WebhookURL))
 	d.Set("default_branch", string(t.DefaultBranch))
+	d.Set("skip_intermediate_builds", bool(t.SkipIntermediateBuilds))
+	d.Set("skip_intermediate_builds_branch_filter", string(t.SkipIntermediateBuildsBranchFilter))
+	d.Set("cancel_intermediate_builds", bool(t.CancelIntermediateBuilds))
+	d.Set("cancel_intermediate_builds_branch_filter", string(t.CancelIntermediateBuildsBranchFilter))
 }

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -62,6 +62,10 @@ func resourcePipeline() *schema.Resource {
 				Required: true,
 				Type:     schema.TypeString,
 			},
+			"default_branch": &schema.Schema{
+				Optional: true,
+				Type:     schema.TypeString,
+			},
 		},
 	}
 }
@@ -77,7 +81,7 @@ func CreatePipeline(d *schema.ResourceData, m interface{}) error {
 	var mutation struct {
 		PipelineCreate struct {
 			Pipeline PipelineNode
-		} `graphql:"pipelineCreate(input: {organizationId: $org, name: $name, description: $desc, repository: {url: $repository_url}, steps: {yaml: $steps}})"`
+		} `graphql:"pipelineCreate(input: {organizationId: $org, name: $name, description: $desc, repository: {url: $repository_url}, steps: {yaml: $steps}, defaultBranch: $default_branch})"`
 	}
 
 	vars := map[string]interface{}{
@@ -86,6 +90,7 @@ func CreatePipeline(d *schema.ResourceData, m interface{}) error {
 		"org":            id,
 		"repository_url": graphql.String(d.Get("repository").(string)),
 		"steps":          graphql.String(d.Get("steps").(string)),
+		"default_branch": graphql.String(d.Get("default_branch").(string)),
 	}
 
 	err = client.graphql.Mutate(context.Background(), &mutation, vars)
@@ -128,7 +133,7 @@ func UpdatePipeline(d *schema.ResourceData, m interface{}) error {
 	var mutation struct {
 		PipelineUpdate struct {
 			Pipeline PipelineNode
-		} `graphql:"pipelineUpdate(input: {id: $id, name: $name, description: $desc, repository: {url: $repository_url}, steps: {yaml: $steps}})"`
+		} `graphql:"pipelineUpdate(input: {id: $id, name: $name, description: $desc, repository: {url: $repository_url}, steps: {yaml: $steps}, defaultBranch: $default_branch})"`
 	}
 
 	vars := map[string]interface{}{
@@ -137,6 +142,7 @@ func UpdatePipeline(d *schema.ResourceData, m interface{}) error {
 		"name":           graphql.String(d.Get("name").(string)),
 		"repository_url": graphql.String(d.Get("repository").(string)),
 		"steps":          graphql.String(d.Get("steps").(string)),
+		"default_branch": graphql.String(d.Get("default_branch").(string)),
 	}
 
 	err := client.graphql.Mutate(context.Background(), &mutation, vars)
@@ -178,4 +184,5 @@ func updatePipeline(d *schema.ResourceData, t *PipelineNode) {
 	d.Set("steps", string(t.Steps.Yaml))
 	d.Set("uuid", string(t.Uuid))
 	d.Set("webhook_url", string(t.WebhookURL))
+	d.Set("default_branch", string(t.DefaultBranch))
 }


### PR DESCRIPTION
Thank you for your work on this provider plugin, @jradtilbrook! Really appreciate it.
Made my job a lot easier 🙂

I noticed that setting the default branch wasn't supported yet, so I implemented that. Empty default branch means all branches, so I tested `default_branch = ""` (which is also the default) and that works without problems.

Build skipping fields were recently added to the GraphQL API (https://forum.buildkite.community/t/feature-parity-for-pipeline-creation-between-graphql-and-rest-apis/600/3), so I implemented them too.