### PR TITLE
Make pipeline teams optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ resource "buildkite_pipeline" "repo2" {
 - `description` - (Optional) A description of the pipeline.
 - `repository` - (Required) The git URL of the repository.
 - `steps` - (Required) The string YAML steps to run the pipeline.
-- `team` - (Optional) Set team access for the pipeline. Can be specified multiple times for each team. Note that non-admin users may receive a buildkite permission error if trying to create a pipeline without at least one team. 
+- `team` - (Optional) Set team access for the pipeline. Can be specified multiple times for each team.  
 
 The `team` block supports:
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ resource "buildkite_pipeline" "repo2" {
     name = "repo2"
     repository = "git@github.com:org/repo2"
     steps = file("./steps.yml")
+
+    team {
+        slug = "everyone"
+        access_level = "READ_ONLY"
+    }
 }
 ```
 
@@ -124,6 +129,12 @@ resource "buildkite_pipeline" "repo2" {
 - `description` - (Optional) A description of the pipeline.
 - `repository` - (Required) The git URL of the repository.
 - `steps` - (Required) The string YAML steps to run the pipeline.
+- `team` - (Optional) Set team access for the pipeline. Can be specified multiple times for each team. Note that non-admin users may receive a buildkite permission error if trying to create a pipeline without at least one team. 
+
+The `team` block supports:
+
+- `slug` - (Required) The buildkite slug of the team.
+- `access_level` - (Required) The level of access to grant. Must be one of `READ_ONLY`, `BUILD_AND_READ` or `MANAGE_BUILD_AND_READ`.
 
 #### Attribute reference
 

--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -99,7 +99,7 @@ func resourcePipeline() *schema.Resource {
 			},
 			"team": {
 				Type:       schema.TypeSet,
-				Required:   true,
+				Optional:   true,
 				ConfigMode: schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
As issue #48 points out, teams are only a thing on paid plans. This makes the team block optional and updates the readme including a warning about non-admin users creating a pipeline without a team. I'd imagine this doesn't error on a free plan but does error on a paid plan.

Resolves #48 