### PR TITLE
Add branch_configuration arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ resource "buildkite_pipeline" "repo2" {
 - `description` - (Optional) A description of the pipeline.
 - `repository` - (Required) The git URL of the repository.
 - `default_branch` - (Optional) The default branch to prefill when new builds are created or triggered.
+- `branch_configuration` - (Optional) Limit which branches and tags cause new builds to be created, either via a code push or via the Builds REST API.
 - `steps` - (Required) The string YAML steps to run the pipeline.
 - `team` - (Optional) Set team access for the pipeline. Can be specified multiple times for each team.  
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ resource "buildkite_pipeline" "repo2" {
 - `name` - (Required) The name of the pipeline.
 - `description` - (Optional) A description of the pipeline.
 - `repository` - (Required) The git URL of the repository.
+- `default_branch` - (Optional) The default branch to prefill when new builds are created or triggered.
 - `steps` - (Required) The string YAML steps to run the pipeline.
 - `team` - (Optional) Set team access for the pipeline. Can be specified multiple times for each team.  
 


### PR DESCRIPTION
### Context

This PR would allow users to configure pipeline-level branch configuration

### Consideration

Because there is no support to update this attribute in GraphQL API. The implementation is done via the RESTful API. It comes with a cost... that is an extra HTTP call after the GraphQL API call just for updating one attribute.