### PR TITLE
Fix character encoding in agent_token docs

### DIFF
--- a/docs/resources/agent_token.md
+++ b/docs/resources/agent_token.md
@@ -26,7 +26,7 @@ resource "buildkite_agent_token" "fleet" {
 * `uuid` - The UUID of the token.
 
 
-## Import
+## Import
 
 Tokens can be imported using the `GraphQL ID` (not UUID), e.g.
 


### PR DESCRIPTION
to: @jradtilbrook 

## Background

<!--
Overview of the changes carried out
-->

#62 added documentation, but there is a whitespace encoding issue. Can be seen here: https://registry.terraform.io/providers/jradtilbrook/buildkite/latest/docs/resources/agent_token

## Changes
<!--
Details about each change
-->

* Fixed whitepsace around `Import` within the markdown

<details>
<summary><code>Visible bug</code></summary>

<img width="737" alt="Screenshot 2020-10-13 at 15 06 52" src="https://user-images.githubusercontent.com/39212456/95872125-5fcc9380-0d66-11eb-9cd4-cda1a46cf1f6.png">

</details>


